### PR TITLE
Update __init__.py: cv.ipv4 -> cv.ipv4address()

### DIFF
--- a/components/loxone/__init__.py
+++ b/components/loxone/__init__.py
@@ -23,7 +23,7 @@ LOXONE_PROTOCOLS = {
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(LoxoneComponent),
     cv.Required("protocol"): cv.enum(LOXONE_PROTOCOLS),
-    cv.Required("loxone_ip"): cv.ipv4,
+    cv.Required("loxone_ip"): cv.ipv4address(),
     cv.Required("loxone_port"): cv.int_range(0, 65535),
     cv.Required("listen_port"): cv.int_range(0, 65535),
     cv.Optional("send_buffer_length", default=20): cv.int_range(0, 1024),

--- a/components/loxone/__init__.py
+++ b/components/loxone/__init__.py
@@ -23,7 +23,7 @@ LOXONE_PROTOCOLS = {
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(LoxoneComponent),
     cv.Required("protocol"): cv.enum(LOXONE_PROTOCOLS),
-    cv.Required("loxone_ip"): cv.ipv4address(),
+    cv.Required("loxone_ip"): cv.ipv4addres,
     cv.Required("loxone_port"): cv.int_range(0, 65535),
     cv.Required("listen_port"): cv.int_range(0, 65535),
     cv.Optional("send_buffer_length", default=20): cv.int_range(0, 1024),


### PR DESCRIPTION
Issue: AttributeError: module 'esphome.config_validation' has no attribute 'ipv4'

If we look at esphome config_validation.py file it has: def ipv4address(value):

So I believe that should be used instead of ipv4

Docs: https://github.com/esphome/esphome/blob/dev/esphome/config_validation.py